### PR TITLE
Fix code

### DIFF
--- a/Playlist.swift
+++ b/Playlist.swift
@@ -6,7 +6,6 @@ public struct Playlist: Codable {
     public var name: String = ""
     public var description: String = ""
     public var ispublic: Bool = false
-    public var user_id: Int = 1
- 
+    public var userId: Int = 1
 }
 

--- a/RequestResponse.swift
+++ b/RequestResponse.swift
@@ -14,10 +14,12 @@ public class RequestResponse {
         var request = URLRequest(url: url)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "POST"
-        
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
         let (dataResponse, response) = try await session.upload(
             for: request,
-            from: try JSONEncoder().encode(encode)
+            from: try encoder.encode(encode)
         )
         
         guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {


### PR DESCRIPTION
There was a couple of problems in your code:

1. You set the decoding strategy to `.convertFromSnakeCase`, but you didn't set the encoder to use that strategy.
2. When you use convert from snake case, Swift is expecting camel cased property names.

This should clear things up! https://www.hackingwithswift.com/example-code/system/how-to-convert-between-camel-case-and-snake-case-with-codable-and-keyencodingstrategy